### PR TITLE
Ignore `links` payload for new objects if empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+0.1.1 / 2015-01-23
+==================
+
+  * Add internal helper #remove_links? for association payloads
+  * Do not send `links: {}` if new object, and empty associations
+
 0.1.0 / 2014-12-03
 ==================
 

--- a/lib/jsonapi/consumer/resource/serializer_concern.rb
+++ b/lib/jsonapi/consumer/resource/serializer_concern.rb
@@ -7,15 +7,13 @@ module JSONAPI::Consumer::Resource
 
       self.each_association do |name, association, options|
         @hash[:links] ||= {}
-        # unless options[:embed] == :ids
-          # @hash[:linked] ||= {}
-        # end
 
         if association.respond_to?(:each)
           add_links(name, association, options)
         else
           add_link(name, association, options)
         end
+        @hash.delete(:links) if @hash[:links].length == 0 && !persisted?
       end
 
       @hash
@@ -31,11 +29,6 @@ module JSONAPI::Consumer::Resource
           obj.to_param
         end
       end
-
-      # unless options[:embed] == :ids
-        # @hash[:linked][name] ||= []
-        # @hash[:linked][name] += association.map { |item| item.attributes(options) }
-      # end
     end
 
     def add_link(name, association, options)
@@ -47,18 +40,10 @@ module JSONAPI::Consumer::Resource
                             else
                               association.to_param
                             end
-
-      # unless options[:embed] == :ids
-        # plural_name = name.to_s.pluralize.to_sym
-
-        # @hash[:linked][plural_name] ||= []
-        # @hash[:linked][plural_name].push association.attributes(options)
-      # end
     end
 
     def to_json(options={})
       serializable_hash(options).to_json
     end
-
   end
 end

--- a/lib/jsonapi/consumer/resource/serializer_concern.rb
+++ b/lib/jsonapi/consumer/resource/serializer_concern.rb
@@ -8,12 +8,12 @@ module JSONAPI::Consumer::Resource
       self.each_association do |name, association, options|
         @hash[:links] ||= {}
 
-        if association.respond_to?(:each)
+        if association.respond_to?(:each) or _association_type(name) == :has_many
           add_links(name, association, options)
         else
           add_link(name, association, options)
         end
-        @hash.delete(:links) if @hash[:links].length == 0 && !persisted?
+        @hash.delete(:links) if remove_links?
       end
 
       @hash
@@ -21,7 +21,7 @@ module JSONAPI::Consumer::Resource
 
     def add_links(name, association, options)
       @hash[:links][name] ||= []
-      @hash[:links][name] += association.map do |obj|
+      @hash[:links][name] += (association || []).map do |obj|
         case obj.class
         when String, Integer
           obj
@@ -44,6 +44,20 @@ module JSONAPI::Consumer::Resource
 
     def to_json(options={})
       serializable_hash(options).to_json
+    end
+
+  private
+
+    def remove_links?
+      if persisted?
+        false
+      else # not persisted, new object
+        if @hash[:links].length == 0 or @hash[:links].values.flatten.empty?
+          true
+        else
+          false
+        end
+      end
     end
   end
 end

--- a/lib/jsonapi/consumer/version.rb
+++ b/lib/jsonapi/consumer/version.rb
@@ -1,5 +1,5 @@
 module Jsonapi
   module Consumer
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
   end
 end

--- a/spec/jsonapi/consumer/associations_spec.rb
+++ b/spec/jsonapi/consumer/associations_spec.rb
@@ -48,8 +48,22 @@ RSpec.describe 'Associations', 'has_many' do
   describe 'the links payload' do
     subject(:payload_hash) { user_instance.serializable_hash }
 
-    it 'has links in output' do
-      expect(payload_hash).to have_key(:links)
+    describe 'when populated' do
+      before do
+        user_instance.posts = ['1']
+      end
+
+      it 'has links in output, if present' do
+        expect(payload_hash).to have_key(:links)
+        expect(payload_hash[:links]).to have_key(:posts)
+        expect(payload_hash[:links][:posts]).to eql(["1"])
+      end
+    end
+
+    describe 'when empty' do
+      it 'has no links in output' do
+        expect(payload_hash).to_not have_key(:links)
+      end
     end
   end
 end

--- a/spec/jsonapi/consumer/associations_spec.rb
+++ b/spec/jsonapi/consumer/associations_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'Associations', 'has_many' do
 
       it 'has links in output, if present' do
         expect(payload_hash).to have_key(:links)
-        expect(payload_hash[:links]).to have_key(:posts)
+        expect(payload_hash[:links]).to eql({posts: ['1']})
         expect(payload_hash[:links][:posts]).to eql(["1"])
       end
     end
@@ -63,6 +63,17 @@ RSpec.describe 'Associations', 'has_many' do
     describe 'when empty' do
       it 'has no links in output' do
         expect(payload_hash).to_not have_key(:links)
+      end
+    end
+
+    describe 'when persisted and empty' do
+      before do
+        allow(user_instance).to receive(:persisted?).and_return(true)
+      end
+
+      it 'has a links hash in the output' do
+        expect(payload_hash).to have_key(:links)
+        expect(payload_hash[:links]).to eql({posts: []})
       end
     end
   end


### PR DESCRIPTION
Prior to this every new object would send a bad payload of `{...., links: {}}`. This fixes this to either include the proper association keys when populated `{...., links: {posts: [1,2,3]}}` or just exclude the value all together `{....}`