### PR TITLE
Top level key must be named 'data'

### DIFF
--- a/lib/jsonapi/consumer/resource.rb
+++ b/lib/jsonapi/consumer/resource.rb
@@ -22,7 +22,7 @@ module JSONAPI::Consumer
       end
 
       def json_key
-        self.name.demodulize.pluralize.underscore
+        'data'
       end
 
       def host
@@ -30,7 +30,7 @@ module JSONAPI::Consumer
       end
 
       def path
-        json_key
+        self.name.demodulize.pluralize.underscore
       end
 
       def ssl


### PR DESCRIPTION
Refer,

http://jsonapi.org/format/#document-structure-top-level

https://github.com/json-api/json-api/pull/341/files#diff-26e38355b69056b0db1c2b1c612241b2R70

For legacy support, one could then put the following on their base resource class:

```ruby
def self.json_key
  path
end
```