### PR TITLE
Top level key must be named 'data' (+type)

### DIFF
--- a/lib/jsonapi/consumer/resource.rb
+++ b/lib/jsonapi/consumer/resource.rb
@@ -22,7 +22,7 @@ module JSONAPI::Consumer
       end
 
       def json_key
-        self.name.demodulize.pluralize.underscore
+        'data'
       end
 
       def host
@@ -30,7 +30,7 @@ module JSONAPI::Consumer
       end
 
       def path
-        json_key
+        self.name.demodulize.pluralize.underscore
       end
 
       def ssl

--- a/spec/fixtures/responses.rb
+++ b/spec/fixtures/responses.rb
@@ -1,8 +1,9 @@
 module Responses
   def self.sideload
     {
-      posts: [
+      data: [
         {
+          type: :posts,
           links: {
             comments: [
               "82083863-bba9-480e-a281-f5d34e7dc0ca",
@@ -16,6 +17,7 @@ module Responses
           updated_at: "2014-10-19T22:32:52.967Z"
         },
         {
+          type: :posts,
           links: {
             comments: [
               "9c9ba83b-024c-4d4c-9573-9fd41b95fc14",
@@ -32,22 +34,26 @@ module Responses
       linked: {
         users: [
           {
+            type: :users,
             id: "6a45992f-cd20-497a-a753-21b2a1a82356",
             name: "Jane Smith"
           },
           {
+            type: :users,
             id: "d65dda70-73eb-461a-bb34-5484e6e8c194",
             name: "Jim Bob"
           }
         ],
         comments: [
           {
+            type: :users,
             id: "82083863-bba9-480e-a281-f5d34e7dc0ca",
             content: "Awesome article",
             created_at: "2014-10-19T22:32:52.933Z",
             updated_at: "2014-10-19T22:32:52.969Z"
           },
           {
+            type: :users,
             id: "3b402e8a-7c35-4915-8c72-07ea7779ab76",
             content: "Hated it",
             created_at: "2014-10-19T22:32:52.933Z",

--- a/spec/jsonapi/consumer/connection_spec.rb
+++ b/spec/jsonapi/consumer/connection_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe 'Connection' do
       stub_request(:get, "http://localhost:3000/api/basic_resources")
         .with(headers: {accept: 'application/json'})
         .to_return(headers: {content_type: "application/json"}, body: {
-          basic_resources: [
-            {id: '1'}
+          data: [
+            {type: :basic_resources, id: '1'}
           ]
         }.to_json)
 
@@ -36,10 +36,10 @@ RSpec.describe 'Connection' do
       stub_request(:get, "http://localhost:3000/api/records")
         .with(headers: {accept: 'application/json'})
         .to_return(headers: {content_type: "application/json"}, body: {
-          records: [
-            {id: '1', name: "foo.example"},
-            {id: '2', name: "bar.example"},
-            {id: '3', name: "baz.example"}
+          data: [
+            {type: :records, id: '1', name: "foo.example"},
+            {type: :records, id: '2', name: "bar.example"},
+            {type: :records, id: '3', name: "baz.example"}
           ]
         }.to_json)
 
@@ -54,15 +54,15 @@ RSpec.describe 'Connection' do
       stub_request(:get, "http://localhost:3000/api/records")
         .with(headers: {accept: 'application/json'})
         .to_return(headers: {content_type: "application/json"}, body: {
-          records: []
+          data: []
         }.to_json) # This should not get called.
 
       stub_request(:get, "http://localhost:3000/api/records?name=foo&email=bar@example.com")
         .with(headers: {accept: 'application/json'})
         .to_return(headers: {content_type: "application/json"}, body: {
-          records: [
-            {id: '1', name: 'bar', email: "bar.example"},
-            {id: '2', name: 'foo', email: "bar.example"},
+          data: [
+            {type: :records, id: '1', name: 'bar', email: "bar.example"},
+            {type: :records, id: '2', name: 'foo', email: "bar.example"},
           ]
         }.to_json)
 
@@ -76,8 +76,8 @@ RSpec.describe 'Connection' do
       stub_request(:get, "http://localhost:3000/api/records/1")
         .with(headers: {accept: 'application/json'})
         .to_return(headers: {content_type: "application/json"}, body: {
-          records: [
-            {id: '1', name: "foobar.example"}
+          data: [
+            {type: :records, id: '1', name: "foobar.example"}
           ]
         }.to_json)
 
@@ -96,8 +96,14 @@ RSpec.describe 'Connection' do
       stub_request(:post, "http://localhost:3000/api/records")
         .with(headers: {accept: 'application/json', content_type: "application/json"})
         .to_return(headers: {content_type: "application/json"}, status: 201, body: {
-          records: [
-            {id: '1', name: "foobar.example", created_at: "2014-10-16T18:49:40Z", updated_at: "2014-10-18T18:59:40Z"}
+          data: [
+            {
+              type: :records,
+              id: '1',
+              name: "foobar.example",
+              created_at: "2014-10-16T18:49:40Z",
+              updated_at: "2014-10-18T18:59:40Z"
+            }
           ]
         }.to_json)
 
@@ -118,8 +124,14 @@ RSpec.describe 'Connection' do
       stub_request(:put, "http://localhost:3000/api/records/1")
         .with(headers: {accept: 'application/json', content_type: "application/json"})
         .to_return(headers: {content_type: "application/json"}, body: {
-          records: [
-            {id: '1', name: "foobar.example", created_at: "2014-10-16T18:49:40Z", updated_at: "2016-10-18T18:59:40Z"}
+          data: [
+            {
+              type: :records,
+              id: '1',
+              name: "foobar.example",
+              created_at: "2014-10-16T18:49:40Z",
+              updated_at: "2016-10-18T18:59:40Z"
+            }
           ]
         }.to_json)
 

--- a/spec/jsonapi/consumer/object_build_spec.rb
+++ b/spec/jsonapi/consumer/object_build_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe 'Object building' do
   it 'returns an object with populated items' do
     stub_request(:get, "http://localhost:3000/api/build_requests/new")
       .to_return(headers: {content_type: "application/json"}, body: {
-          build_requests: [
-            {name: "", title: "default value"}
+          data: [
+            {type: :build_requests, name: "", title: "default value"}
           ]
         }.to_json)
 

--- a/spec/jsonapi/consumer/parser_spec.rb
+++ b/spec/jsonapi/consumer/parser_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe 'Response Parsing' do
   it 'can handle linked associations' do
     stub_request(:get, 'http://localhost:3000/api/comments/9c9ba83b-024c-4d4c-9573-9fd41b95fc14')
       .to_return(headers: {content_type: "application/json"}, body: {
-          comments: [
+          data: [
             {
+              type: :comments,
               id: '9c9ba83b-024c-4d4c-9573-9fd41b95fc14',
               content: "i found this useful."
             }
@@ -17,8 +18,9 @@ RSpec.describe 'Response Parsing' do
 
     stub_request(:get, 'http://localhost:3000/api/comments/27fcf6e8-24b0-41db-94b1-812046a10f54')
       .to_return(headers: {content_type: "application/json"}, body: {
-          comments: [
+          data: [
             {
+              type: :comments,
               id: '27fcf6e8-24b0-41db-94b1-812046a10f54',
               content: "i found this useful too."
             }


### PR DESCRIPTION
Refer,

http://jsonapi.org/format/#document-structure-top-level

https://github.com/json-api/json-api/pull/341/files#diff-26e38355b69056b0db1c2b1c612241b2R70

For legacy support, one could then put the following on their base resource class:

```ruby
def self.json_key
  path
end
```