### PR TITLE
Access associations via another object.

### DIFF
--- a/lib/jsonapi/consumer.rb
+++ b/lib/jsonapi/consumer.rb
@@ -39,3 +39,6 @@ require "jsonapi/consumer/resource/finders_concern"
 require "jsonapi/consumer/resource/object_build_concern"
 require "jsonapi/consumer/resource/serializer_concern"
 require "jsonapi/consumer/resource"
+
+require "jsonapi/consumer/association/base"
+require "jsonapi/consumer/association/has_many"

--- a/lib/jsonapi/consumer/association/base.rb
+++ b/lib/jsonapi/consumer/association/base.rb
@@ -1,0 +1,80 @@
+module JSONAPI::Consumer::Association
+  class Base
+    attr_accessor :attribute_name, :options, :resource_class
+
+    def initialize(resource_class, options)
+      self.resource_class = resource_class
+      self.options = options
+      self.attribute_name = options[:attribute_name]
+      self.class::ResourceMethods.attach(resource_class, self)
+    end
+
+    def read(resource_instance)
+      resource_instance._association_data[attribute_name]
+    end
+
+    def write(resource_instance, val)
+      resource_instance._association_data[attribute_name] = cast(val)
+    end
+
+    def cast(value)
+      return if value.is_a?(Array) && @options[:type] != :has_many
+      return value if value.nil?
+
+      association_class = _association_class
+
+      case value
+        when association_class
+          value
+        when Array
+          value.collect {|i| cast(i) }
+        when Hash
+          association_class.new(value)
+        when NilClass
+          nil
+        else
+          association_class.new({association_class.primary_key => value})
+      end
+    end
+
+    def _association_class
+      if @options[:class_name]
+        begin
+          @options[:class_name].constantize
+        rescue NameError
+          raise MisconfiguredAssociation,
+                "#{self}##{self.options[:type]} #{attribute_name} has a class_name specified that does not exist."
+        end
+      else
+        raise MisconfiguredAssociation,
+              "#{self}##{self.options[:type]} #{attribute_name} is missing an explicit `:class_name` value."
+      end
+    end
+
+    module ResourceMethods
+      def self.attach(resource_class, association)
+
+        define_method association.attribute_name do
+          association.read(self)
+        end
+
+        define_method :"#{association.attribute_name.to_s.singularize}_id" do
+          if obj = association.read(self)
+            obj.send(obj.primary_key)
+          end
+        end
+
+        define_method :"#{association.attribute_name}=" do |val|
+          association.write(self, val)
+        end
+
+         define_method :_association_data do
+          @_association_data ||= {}
+        end
+
+        resource_class.include self
+      end
+    end
+
+  end
+end

--- a/lib/jsonapi/consumer/association/has_many.rb
+++ b/lib/jsonapi/consumer/association/has_many.rb
@@ -1,25 +1,32 @@
 module JSONAPI::Consumer::Association
   class HasMany < Base
-    module ResourceMethods
-      def self.attach(resource_class, association)
 
-        define_method association.attribute_name do
-          association.read(self)
+    def read
+      @value ||= []
+    end
+
+    module ResourceMethods
+      def self.attach(resource_class, association_class, options)
+
+        attribute_name = options[:attribute_name]
+        define_method attribute_name do
+          send("#{attribute_name}_association").read
         end
 
-        define_method :"#{association.attribute_name.to_s.singularize}_ids" do
-          if objs = association.read(self)
+        define_method :"#{attribute_name.to_s.singularize}_ids" do
+          if objs = send("#{attribute_name}_association").read
             objs.collect {|o| o.send(o.primary_key)}
           end
         end
 
-        define_method :"#{association.attribute_name}=" do |val|
+        define_method :"#{attribute_name}=" do |val|
           val = [val].flatten unless val.nil?
-          association.write(self, val)
+          send("#{attribute_name}_association").write(val)
         end
 
-        define_method :_association_data do
-          @_association_data ||= {}
+        define_method :"#{attribute_name}_association" do
+          @_associations ||= {}
+          @_associations[attribute_name] ||= association_class.new(self, options)
         end
 
         resource_class.include self

--- a/lib/jsonapi/consumer/association/has_many.rb
+++ b/lib/jsonapi/consumer/association/has_many.rb
@@ -1,0 +1,30 @@
+module JSONAPI::Consumer::Association
+  class HasMany < Base
+    module ResourceMethods
+      def self.attach(resource_class, association)
+
+        define_method association.attribute_name do
+          association.read(self)
+        end
+
+        define_method :"#{association.attribute_name.to_s.singularize}_ids" do
+          if objs = association.read(self)
+            objs.collect {|o| o.send(o.primary_key)}
+          end
+        end
+
+        define_method :"#{association.attribute_name}=" do |val|
+          val = [val].flatten unless val.nil?
+          association.write(self, val)
+        end
+
+        define_method :_association_data do
+          @_association_data ||= {}
+        end
+
+        resource_class.include self
+      end
+    end
+
+  end
+end

--- a/lib/jsonapi/consumer/parser.rb
+++ b/lib/jsonapi/consumer/parser.rb
@@ -36,12 +36,12 @@ module JSONAPI::Consumer
     end
 
     def fetch_linked(assoc_name, id)
-      klass._association_for(assoc_name)._association_class.find(id)
+      klass._association_class(assoc_name).find(id)
     end
 
     def find_linked(assoc_name, id)
       if found = linked.fetch(assoc_name.pluralize, []).detect {|h| h.fetch(:id) == id }
-        klass._association_for(assoc_name)._association_class.new(attributes(found), false)
+        klass._association_class(assoc_name).new(attributes(found))
       else
         fetch_linked(assoc_name, id)
       end

--- a/lib/jsonapi/consumer/parser.rb
+++ b/lib/jsonapi/consumer/parser.rb
@@ -36,12 +36,12 @@ module JSONAPI::Consumer
     end
 
     def fetch_linked(assoc_name, id)
-      klass._association_class_name(assoc_name).find(id)
+      klass._association_for(assoc_name)._association_class.find(id)
     end
 
     def find_linked(assoc_name, id)
       if found = linked.fetch(assoc_name.pluralize, []).detect {|h| h.fetch(:id) == id }
-        klass._association_class_name(assoc_name).new(found)
+        klass._association_for(assoc_name)._association_class.new(attributes(found), false)
       else
         fetch_linked(assoc_name, id)
       end

--- a/lib/jsonapi/consumer/resource.rb
+++ b/lib/jsonapi/consumer/resource.rb
@@ -81,8 +81,6 @@ module JSONAPI::Consumer
           set_attribute($1, args.first)
         elsif has_attribute?(method)
           read_attribute(method)
-        elsif has_association?(method)
-          read_assocation(method)
         else
           super
         end

--- a/lib/jsonapi/consumer/resource/serializer_concern.rb
+++ b/lib/jsonapi/consumer/resource/serializer_concern.rb
@@ -8,7 +8,7 @@ module JSONAPI::Consumer::Resource
       self.each_association do |name, association, options|
         @hash[:links] ||= {}
 
-        if association.respond_to?(:each) or _association_type(name) == :has_many
+        if association.respond_to?(:each) or options[:type] == :has_many
           add_links(name, association, options)
         else
           add_link(name, association, options)

--- a/spec/jsonapi/consumer/associations_spec.rb
+++ b/spec/jsonapi/consumer/associations_spec.rb
@@ -43,6 +43,12 @@ RSpec.describe 'Associations', 'has_many' do
         user_instance.posts = nil
       }.to change{user_instance.post_ids}.from(['1']).to(nil)
     end
+
+    it 'can be pushed on' do
+      expect {
+        user_instance.posts << '1'
+      }.to change{user_instance.post_ids}.from(nil).to(['1'])
+    end
   end
 
   describe 'the links payload' do

--- a/spec/jsonapi/consumer/associations_spec.rb
+++ b/spec/jsonapi/consumer/associations_spec.rb
@@ -28,26 +28,26 @@ RSpec.describe 'Associations', 'has_many' do
     it 'can be added as a single value' do
       expect {
         user_instance.posts = '1'
-      }.to change{user_instance.post_ids}.from(nil).to(['1'])
+      }.to change{user_instance.post_ids}.from([]).to(['1'])
     end
 
     it 'can be added as a list of items' do
       expect {
         user_instance.posts = ['1','2','3']
-      }.to change{user_instance.post_ids}.from(nil).to(['1','2','3'])
+      }.to change{user_instance.post_ids}.from([]).to(['1','2','3'])
     end
 
     it 'can be blanked out' do
       user_instance.posts = '1'
       expect {
         user_instance.posts = nil
-      }.to change{user_instance.post_ids}.from(['1']).to(nil)
+      }.to change{user_instance.post_ids}.from(['1']).to([])
     end
 
     it 'can be pushed on' do
       expect {
-        user_instance.posts << '1'
-      }.to change{user_instance.post_ids}.from(nil).to(['1'])
+        user_instance.posts << Post.new(id: '1')
+      }.to change{user_instance.post_ids}.from([]).to(['1'])
     end
   end
 

--- a/spec/jsonapi/consumer/parser_spec.rb
+++ b/spec/jsonapi/consumer/parser_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe 'Response Parsing' do
 
     expect(results.size).to eql(2)
 
+    expect(Blog::Post._association_options[:user][:class_name]).to eq 'Blog::User'
+    results = parser.build
     result = results.first
     expect(result.comments.size).to eql(2)
     expect(result.user).to be_a(Blog::User)


### PR DESCRIPTION
I'm keen for feedback on this, and whether it is a good idea. I understand it is probably quite a considerable change. Particularly let me know if you're comfortable with the change in behaviour represented by the change in the specs. 

There's definitely more refactoring that could be done, but would like some feedback beforehand. 

Basically, I wished for the ability to 'push' a new record onto a has-many association. The reading and writing to an association would have different behaviour depending on the type of the association, so I thought that it might be a good place to have different objects managing the behaviour. 

I've tried to make sure as much of the logic as possible is retained in each instance of an association, and have the class simply retain the ```_association_options``` hash.

Also, I just looked at the ResourceMethods.attach method I'd made. I am now wondering if the methods it dynamically defines would be retained the next time the same module is used, or if each module is its own instance. Having it retain its methods between calls would not be good. I might have to do a bit of reading up on Ruby modules.