### PR TITLE
Feature/persistence

### DIFF
--- a/lib/jsonapi/consumer/parser.rb
+++ b/lib/jsonapi/consumer/parser.rb
@@ -8,7 +8,7 @@ module JSONAPI::Consumer
     end
 
     def attributes(item)
-      item.except(:links)
+      item.except(:links, :type, :href)
     end
 
     def associations(item)
@@ -60,7 +60,7 @@ module JSONAPI::Consumer
     def build
       _body.fetch(klass.json_key, []).collect do |attrs|
         attrs_hash = attributes(attrs).merge(associations(attrs))
-        klass.new(attrs_hash)
+        klass.new(attrs_hash, false)
       end
     end
 

--- a/lib/jsonapi/consumer/query/base.rb
+++ b/lib/jsonapi/consumer/query/base.rb
@@ -3,19 +3,23 @@ module JSONAPI::Consumer::Query
     class << self
       attr_accessor :request_method
     end
-    attr_reader :klass, :headers, :path, :params
+    attr_reader :klass, :path, :headers, :params
 
     def initialize(klass, payload)
       @klass = klass
       build_params(payload) if payload.is_a?(Hash) && payload.keys != [klass.primary_key]
 
       @path = begin
-                if payload.is_a?(Hash) && payload.has_key?(klass.primary_key)
-                  [klass.path, payload.delete(klass.primary_key)].join('/')
+                if payload.is_a?(Hash) && persisted? && payload.has_key?(klass.primary_key)
+                  [klass.path, payload.fetch(klass.primary_key)].join('/')
                 else
                   klass.path
                 end
               end
+    end
+
+    def persisted?
+      false
     end
 
     def build_params(args)

--- a/lib/jsonapi/consumer/query/delete.rb
+++ b/lib/jsonapi/consumer/query/delete.rb
@@ -5,6 +5,10 @@ module JSONAPI::Consumer::Query
     def params
       nil
     end
+
+    def persisted?
+      true
+    end
   end
 end
 

--- a/lib/jsonapi/consumer/query/find.rb
+++ b/lib/jsonapi/consumer/query/find.rb
@@ -12,5 +12,9 @@ module JSONAPI::Consumer::Query
                   {klass.primary_key => args}
                 end
     end
+
+    def persisted?
+      true
+    end
   end
 end

--- a/lib/jsonapi/consumer/query/update.rb
+++ b/lib/jsonapi/consumer/query/update.rb
@@ -6,6 +6,10 @@ module JSONAPI::Consumer::Query
       args = args.dup
       @params = {klass.json_key => args.except(klass.primary_key)}
     end
+
+    def persisted?
+      true
+    end
   end
 end
 

--- a/lib/jsonapi/consumer/resource.rb
+++ b/lib/jsonapi/consumer/resource.rb
@@ -48,7 +48,8 @@ module JSONAPI::Consumer
       end
     end
 
-    def initialize(params={})
+    def initialize(params={}, new_record = true)
+      @new_record = new_record
       (params || {}).slice(*association_names).each do |key, value|
         send(:"#{key}=", value)
       end

--- a/lib/jsonapi/consumer/resource/attributes_concern.rb
+++ b/lib/jsonapi/consumer/resource/attributes_concern.rb
@@ -24,7 +24,11 @@ module JSONAPI::Consumer::Resource
     end
 
     def persisted?
-      !self.to_param.blank?
+      !new_record?
+    end
+
+    def new_record?
+      @new_record
     end
 
     def to_param

--- a/lib/jsonapi/consumer/resource/connection_concern.rb
+++ b/lib/jsonapi/consumer/resource/connection_concern.rb
@@ -56,6 +56,7 @@ module JSONAPI::Consumer
 
       if self.errors.empty?
         self.attributes = results.first.attributes
+        @new_record = false
         true
       else
         false

--- a/lib/jsonapi/consumer/resource/serializer_concern.rb
+++ b/lib/jsonapi/consumer/resource/serializer_concern.rb
@@ -3,7 +3,7 @@ module JSONAPI::Consumer::Resource
     extend ActiveSupport::Concern
 
     def serializable_hash(options={})
-      @hash = persisted? ? attributes : attributes.except(self.class.primary_key)
+      @hash = self.to_param.blank? ? attributes.except(self.class.primary_key) : attributes
 
       self.each_association do |name, association, options|
         @hash[:links] ||= {}

--- a/spec/jsonapi/consumer/attributes_spec.rb
+++ b/spec/jsonapi/consumer/attributes_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe 'Attributes' do
   let(:test_class) do
-    Class.new do
+    AttrRecord ||= Class.new do
       include JSONAPI::Consumer::Resource
+      self.host = 'http://localhost:3000/api/'
     end
   end
 
@@ -17,11 +18,47 @@ RSpec.describe 'Attributes' do
     end
   end
 
-  describe '#persisted?' do
-    it 'uses the primary key to decide' do
+  describe '#new_record? / #peristed?' do
+    it 'changed only after saving' do
+      stub_request(:post, "http://localhost:3000/api/attr_records")
+        .with(headers: {accept: 'application/json', content_type: "application/json"})
+        .to_return(headers: {content_type: "application/json"}, status: 201, body: {
+          attr_records: [
+            {
+              type: :records,
+              id: '1',
+              name: "foobar.example",
+              created_at: "2014-10-16T18:49:40Z",
+              updated_at: "2014-10-18T18:59:40Z"
+            }
+          ]
+        }.to_json)
+      obj.id = '8'
       expect {
-        obj.id = '8'
-      }.to change{obj.persisted?}.from(false).to(true)
+        obj.save
+      }.to change{obj.new_record?}.from(true).to(false)
+    end
+    it 'is persisted after loading' do
+      stub_request(:get, "http://localhost:3000/api/attr_records/1")
+        .with(headers: {accept: 'application/json'})
+        .to_return(headers: {content_type: "application/json"}, body: {
+          attr_records: [
+            {type: :records, id: '1', name: "foobar.example"}
+          ]
+        }.to_json)
+      stub_request(:get, "http://localhost:3000/api/attr_records")
+        .with(headers: {accept: 'application/json'})
+        .to_return(headers: {content_type: "application/json"}, body: {
+          attr_records: [
+            {type: :records, id: '1', name: "foo.example"},
+            {type: :records, id: '2', name: "bar.example"},
+            {type: :records, id: '3', name: "baz.example"}
+          ]
+        }.to_json)
+      expect(test_class.all.all?{|record| record.new_record?}).to eq false
+      expect(test_class.all.all?{|record| record.persisted?}).to eq true
+      expect(test_class.find(1).first.new_record?).to eq false
+      expect(test_class.find(1).first.persisted?).to eq true
     end
   end
 end

--- a/spec/jsonapi/consumer/connection_spec.rb
+++ b/spec/jsonapi/consumer/connection_spec.rb
@@ -124,6 +124,7 @@ RSpec.describe 'Connection' do
         }.to_json)
 
       obj.id = '1'
+      obj.instance_variable_set(:@new_record, false)
       obj.updated_at = "2014-10-18T18:59:40Z"
       expect(obj.updated_at).to eql("2014-10-18T18:59:40Z")
 

--- a/spec/jsonapi/consumer/connection_spec.rb
+++ b/spec/jsonapi/consumer/connection_spec.rb
@@ -123,13 +123,11 @@ RSpec.describe 'Connection' do
           ]
         }.to_json)
 
-      obj.id = '1'
-      obj.instance_variable_set(:@new_record, false)
-      obj.updated_at = "2014-10-18T18:59:40Z"
-      expect(obj.updated_at).to eql("2014-10-18T18:59:40Z")
-
-      expect(obj.save).to eql(true)
-      expect(obj.updated_at).to eql("2016-10-18T18:59:40Z")
+      persisted_object = test_class.new({name: 'jsonapi.example', id: '1'}, false)
+      persisted_object.updated_at = "2014-10-18T18:59:40Z"
+      expect(persisted_object.updated_at).to eql("2014-10-18T18:59:40Z")
+      expect(persisted_object.save).to eql(true)
+      expect(persisted_object.updated_at).to eql("2016-10-18T18:59:40Z")
     end
   end
 

--- a/spec/jsonapi/consumer/connection_spec.rb
+++ b/spec/jsonapi/consumer/connection_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Connection' do
     end
   end
 
-  let(:obj) { test_class.new(name: 'jsonapi.example') }
+  let(:obj) { test_class.new(name: 'jsonapi.example', id: 'client_provided_id') }
 
   describe 'custom connection middleware' do
 


### PR DESCRIPTION
This is changing the way jsonapi-consumer decides if an object is persisted or not. It no longer checks for the existence of an ID attribute and instead sets flags when an object is loaded. I tried to draw inspiration from how ActiveRecord does it, but its a much simpler implementation.

The reasoning behind this change is that I read the JSONAPI spec as almost encouraging the use of client-supplied IDs. If jsonapi-consumer assumes that a new record with an ID is persisted, then the wrong actions would be taken.

I'm not completely happy with adding another parameter to the initialise method, but it seemed like the path of least resistance for now.

In the query classes, I've added methods that signify whether the query type is to be used for a new record or for an existing record (e.g. create vs update query). This I see as a pragmatic way of influencing how the path is built during the instantiation of the query.

To simulate a persisted object in a spec, one would pass false as the second parameter (new_record) when instantiating the object, e.g.
```ruby 
persisted_object = test_class.new({name: 'jsonapi.example', id: '1'}, false)
```