### PR TITLE
Use request_store instead of Thread directly to allow around_filter

### DIFF
--- a/jsonapi-consumer.gemspec
+++ b/jsonapi-consumer.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "faraday_middleware"
   spec.add_runtime_dependency "addressable", '~> 2.5.2'
   spec.add_runtime_dependency "activemodel", '>= 3.2'
+  spec.add_runtime_dependency "request_store", '>= 1.4'
 
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "mocha"

--- a/lib/jsonapi/consumer.rb
+++ b/lib/jsonapi/consumer.rb
@@ -8,6 +8,7 @@ require "forwardable"
 require "faraday"
 require "faraday_middleware"
 require "addressable/uri"
+require "request_store"
 
 module JSONAPI
   module Consumer

--- a/lib/jsonapi/consumer/resource.rb
+++ b/lib/jsonapi/consumer/resource.rb
@@ -142,10 +142,11 @@ module JSONAPI::Consumer
       # @param headers [Hash] The headers to send along
       # @param block [Block] The block where headers will be set for
       def with_headers(headers)
+        existing_headers = self.custom_headers
         self._custom_headers = headers
         yield
       ensure
-        self._custom_headers = {}
+        self._custom_headers = existing_headers
       end
 
       # The current custom headers to send with any request made by this
@@ -317,11 +318,11 @@ module JSONAPI::Consumer
       end
 
       def _custom_headers=(headers)
-        _header_store.replace(headers)
+        RequestStore.store["jsonapi-consumer-#{resource_name}"] = headers
       end
 
       def _header_store
-        Thread.current["json_api_client-#{resource_name}"] ||= {}
+        RequestStore.store["jsonapi-consumer-#{resource_name}"] ||= {}
       end
 
       def _build_connection(rebuild = false)

--- a/lib/jsonapi/consumer/resource.rb
+++ b/lib/jsonapi/consumer/resource.rb
@@ -1,4 +1,3 @@
-
 module JSONAPI::Consumer
   class Resource
     extend ActiveModel::Naming

--- a/lib/jsonapi/consumer/version.rb
+++ b/lib/jsonapi/consumer/version.rb
@@ -1,5 +1,5 @@
 module Jsonapi
   module Consumer
-    VERSION = "1.0.1"
+    VERSION = "2.0.0"
   end
 end


### PR DESCRIPTION
## Background

I was noticing some issues with `Thread.local` code when it came to setting / clearing headers when running multiple Puma workers. This was tracked down to a few things: 

## Changes

* Using `Hash#replace` mutated the headers hash instead of just replacing it with the custom_headers value.
* Using `Resource.with_headers(...)` would clear out custom headers instead of just resetting them to their original value.
* `Thread.current` was not clearing when using Puma. Moved to using [request_store](https://github.com/steveklabnik/request_store) to handle these technical hurdles.