### PR TITLE
Allow parser to handle a namespace

### DIFF
--- a/lib/jsonapi/consumer/parsers/parser.rb
+++ b/lib/jsonapi/consumer/parsers/parser.rb
@@ -80,7 +80,7 @@ module JSONAPI::Consumer
         def choose_model_for(result_set, res)
           return result_set.record_class unless res['type']
 
-          res_type_name = res['type'].underscore.classify
+          res_type_name = [result_set.record_class.namespace, res['type']].compact.join('/').underscore.classify
           (res_type_name.safe_constantize) ? res_type_name.safe_constantize : result_set.record_class
         end
 

--- a/lib/jsonapi/consumer/resource.rb
+++ b/lib/jsonapi/consumer/resource.rb
@@ -27,6 +27,7 @@ module JSONAPI::Consumer
                     :associations,
                     :json_key_format,
                     :route_format,
+                    :namespace,
                     instance_accessor: false
     self.primary_key          = :id
     self.parser               = Parsers::Parser
@@ -39,6 +40,7 @@ module JSONAPI::Consumer
     self.read_only_attributes = [:id, :type, :links, :meta, :relationships]
     self.requestor_class      = Query::Requestor
     self.associations         = []
+    self.namespace            = nil
 
     #:underscored_key, :camelized_key, :dasherized_key, or custom
     self.json_key_format = :underscored_key

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,6 +35,12 @@ class UserPreference < TestResource
   self.primary_key = :user_id
 end
 
+module Namespaced
+  class Article < TestResource
+    self.namespace = 'namespaced'
+  end
+end
+
 def with_altered_config(resource_class, changes)
   # remember and overwrite config
   old_config_values = {}

--- a/test/unit/parser_test.rb
+++ b/test/unit/parser_test.rb
@@ -56,4 +56,31 @@ class ParserTest < MiniTest::Test
     assert_nil author
   end
 
+  def test_can_find_namespaced_object
+    stub_request(:get, "http://example.com/articles/1")
+    .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+      data: {
+        type: "articles",
+        id: "1",
+        attributes: { title: "Rails is Omakase" },
+        relationships: {
+          author: {
+            links: {
+              related: "http://example.com/articles/1/author"
+            }
+          }
+        }
+      }
+    }.to_json)
+
+    articles = Namespaced::Article.find(1)
+    assert articles.is_a?(JSONAPI::Consumer::ResultSet)
+    assert_equal 1, articles.length
+
+    article = articles.first
+    assert_equal "1", article.id
+    assert_equal "Rails is Omakase", article.title
+    assert article.is_a?(Namespaced::Article)
+  end
+
 end


### PR DESCRIPTION
This PR allows a namespace to be handle by defining it as a class variable either in as base record or individual object classes.