### PR TITLE
Add to_ary method to Query::Builder class

### DIFF
--- a/lib/jsonapi/consumer/query/builder.rb
+++ b/lib/jsonapi/consumer/query/builder.rb
@@ -89,6 +89,7 @@ module JSONAPI::Consumer
         @to_a ||= find
       end
       alias all to_a
+      alias to_ary to_a
 
       def find(args = {})
         case args


### PR DESCRIPTION
Without that method nested associations didn't work in Rails forms. I was getting the error:

```
undefined method `persisted?' for []:JSONAPI::Consumer::ResultSet

/Users/michal/.rvm/gems/ruby-2.5.1/bundler/gems/jsonapi-consumer-ba1136bfe7e1/lib/jsonapi/consumer/query/builder.rb:105:in `public_send'
/Users/michal/.rvm/gems/ruby-2.5.1/bundler/gems/jsonapi-consumer-ba1136bfe7e1/lib/jsonapi/consumer/query/builder.rb:105:in `method_missing'
actionview (5.0.7) lib/action_view/helpers/form_helper.rb:1922:in `fields_for_nested_model'
actionview (5.0.7) lib/action_view/helpers/form_helper.rb:1916:in `fields_for_with_nested_attributes'
actionview (5.0.7) lib/action_view/helpers/form_helper.rb:1561:in `fields_for'
```

This happens because Rails performs this check:
https://github.com/rails/rails/blob/v5.0.7/actionview/lib/action_view/helpers/form_helper.rb#L1903

Since our `Builder` did not respond to `to_ary`, Rails assumed it would respond to `persisted?`.